### PR TITLE
match from beginning

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -192,7 +192,7 @@ export function compile(document: Document): Compiled {
       return {
         name,
         path: swagger.paths[name],
-        regex: new RegExp(basePath.replace(/\/*$/, '') + name.replace(/\{[^}]*}/g, '[^/]+') + '/?$'),
+        regex: new RegExp('^' + basePath.replace(/\/*$/, '') + name.replace(/\{[^}]*}/g, '[^/]+') + '/?$'),
         expected: (name.match(/[^\/]+/g) || []).map((s) => s.toString())
       };
     });


### PR DESCRIPTION
Hey, I have two similar routes looks like following:
```
/conversation/{id}/comment/{commentId}
/comment/{commentId}
```
and it would break the validator, because it looks for match from the end of the string.

If there any specific reason that we don't match from the beginning of the path? And where shall I add test for this? Don't find a `compiler.spec.ts`.