### PR TITLE
Remove FS.read requirement for schema.json to resolve issues with bundling tools

### DIFF
--- a/src/document.ts
+++ b/src/document.ts
@@ -28,14 +28,14 @@
  THE SOFTWARE.
  */
 
-import * as fs from 'fs';
 import * as jsonValidator from 'is-my-json-valid';
 import * as YAML from 'yamljs';
 
 import {Document} from './schema';
+import * as schema from './schema.json';
 
 // build a swagger validator from the official v2.0 schema
-const schemaValidator = jsonValidator(JSON.parse(fs.readFileSync(__dirname + '/schema.json', 'utf8')));
+const schemaValidator = jsonValidator(schema);
 
 /*
  * Validate a swagger document against the 2.0 schema, returning a typed Document object.

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -39,3 +39,8 @@ declare module 'json-schema-deref-sync' {
   let x: any;
   export = x;
 }
+
+declare module '*.json' {
+  const value: any;
+  export default value;
+}


### PR DESCRIPTION
Resolves issue when using this module with webpack or other minification tool. The use of fs.read to import schema.json prevents webpack being able to resolve the dependency at bundle time. 

Following changes made: 
- added typing to support import of  *.json
- schema.json switched over to an import - removed fs.read
